### PR TITLE
Use `gitskan` as CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # gitskan
 
-A CLI tool for scanning directories and displaying Git repository status information. `gitskan` is a fork of [gits-statuses](https://github.com/nicolgit/gits-statuses) which provides a comprehensive overview of all your Git repositories in a clean, tabular format.
+A CLI tool for scanning directories and displaying Git repository status information. `gitskan` is a fork of [gits-statuses](https://github.com/nicolgit/gits-statuses) which provides scripts to get a comprehensive overview of all your Git repositories in a clean, tabular format.
 
 Notes:
-- This fork was catalyzed by this [GitHub issue](https://github.com/nicolgit/gits-statuses/issues/1)
-- This is meant to implement the exact functionality but in a single CLI executable
-- Renamed to `gitskan` as to not conflict with `gits-statuses` and to further simplify CLI command
-  - Executable name in CLI: `gsk`
+- `gitskan` was catalyzed by this [GitHub Issue](https://github.com/nicolgit/gits-statuses/issues/1)
+- Implements a single CLI utility that can:
+  - Be distributed to and downloaded from PyPi via (`pip` or `uv`)
+  - Used globally as a bona fide CLI utility
+  - Simplify both installation and usage for the end user
+  - Run on any terminal
 
 ## Features
 
@@ -41,17 +43,12 @@ This scans your directories and displays:
 - [uv](https://docs.astral.sh/uv/)
 
 ### Install with uv (Recommended)
-Note: This is only being temporarily published as an OS CLI tool to PyPi to showcase how it can be distributed and used. The hope is to merge this fork!
-
 ```bash
-# Install uv if you haven't already
-pip install uv     # or brew install uv on mac
-
 # Install gitskan
 uv tool install gitskan
 
 # Verify installation
-gsk --version
+gitskan --version
 ```
 
 ## Usage
@@ -60,16 +57,16 @@ gsk --version
 
 ```bash
 # Basic usage - scan current directory
-gsk
+gitskan
 
 # Detailed view with remote URLs and total commits
-gsk --detailed
+gitskan --detailed
 
 # Scan a specific directory
-gsk --path /path/to/projects
+gitskan --path /path/to/projects
 
 # Show help
-gsk --help
+gitskan --help
 ```
 
 ### Examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gitskan"
-version = "0.0.6"
+version = "0.0.7"
 description = "A CLI tool to scan directories for Git repositories and display their status information."
 requires-python = ">=3.8"
 authors = [
@@ -37,7 +37,7 @@ dev = [
 ]
 
 [project.scripts]
-gsk = "cli:main"
+gitskan = "cli:main"
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/src/cli.py
+++ b/src/cli.py
@@ -23,7 +23,7 @@ def create_parser() -> argparse.ArgumentParser:
         argparse.ArgumentParser: The argument parser.
     """
     parser = argparse.ArgumentParser(
-        prog="gsk",
+        prog="gitskan",
         description="Git repository status scanner - Displays status information for Git repositories",
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,7 @@ class TestCreateParser:
         parser = create_parser()
 
         # Test version argument is present
-        with patch("sys.argv", ["gsk", "--version"]):
+        with patch("sys.argv", ["gitskan", "--version"]):
             with pytest.raises(SystemExit) as exc_info:
                 parser.parse_args(["--version"])
             assert exc_info.value.code == 0
@@ -65,7 +65,7 @@ class TestMain:
         mock_scanner.scan.return_value = []
         mock_scanner_class.return_value = mock_scanner
 
-        with patch("sys.argv", ["gsk"]):
+        with patch("sys.argv", ["gitskan"]):
             with patch("builtins.print") as mock_print:
                 result = main()
 
@@ -108,7 +108,7 @@ class TestMain:
         mock_formatter.format_repositories.return_value = "Repository table"
         mock_formatter.format_summary.return_value = "Summary table"
 
-        with patch("sys.argv", ["gsk"]):
+        with patch("sys.argv", ["gitskan"]):
             with patch("builtins.print"):
                 result = main()
 
@@ -130,7 +130,7 @@ class TestMain:
         """Test main function when git is not available."""
         mock_check_git.return_value = False
 
-        with patch("sys.argv", ["gsk"]):
+        with patch("sys.argv", ["gitskan"]):
             with patch("cli.print_error") as mock_print_error:
                 result = main()
 
@@ -154,7 +154,7 @@ class TestMain:
         mock_scanner.scan.side_effect = KeyboardInterrupt()
         mock_scanner_class.return_value = mock_scanner
 
-        with patch("sys.argv", ["gsk"]):
+        with patch("sys.argv", ["gitskan"]):
             with patch("builtins.print") as mock_print:
                 result = main()
 
@@ -175,7 +175,7 @@ class TestMain:
         mock_scanner.scan.side_effect = Exception("Test error")
         mock_scanner_class.return_value = mock_scanner
 
-        with patch("sys.argv", ["gsk"]):
+        with patch("sys.argv", ["gitskan"]):
             with patch("cli.print_error") as mock_print_error:
                 result = main()
 
@@ -209,7 +209,7 @@ class TestMain:
         mock_formatter.format_repositories.return_value = "Detailed table"
         mock_formatter.format_summary.return_value = "Summary"
 
-        with patch("sys.argv", ["gsk", "--detailed"]):
+        with patch("sys.argv", ["gitskan", "--detailed"]):
             result = main()
 
         assert result == 0
@@ -233,7 +233,7 @@ class TestMain:
         mock_scanner_class.return_value = mock_scanner
 
         custom_path = "/custom/path"
-        with patch("sys.argv", ["gsk", "--path", custom_path]):
+        with patch("sys.argv", ["gitskan", "--path", custom_path]):
             result = main()
 
         assert result == 0
@@ -250,7 +250,7 @@ class TestMainIntegration:
             mock_main.return_value = 0
 
             # Simulate calling from command line
-            with patch("sys.argv", ["gsk"]):
+            with patch("sys.argv", ["gitskan"]):
                 from cli import main
 
                 result = main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,7 +17,7 @@ class TestCliIntegration:
     @patch("cli.validate_path")
     @patch("cli.GitScanner")
     @patch("cli.TableFormatter")
-    @patch("sys.argv", ["gsk"])
+    @patch("sys.argv", ["gitskan"])
     def test_cli_full_workflow_no_repositories(
         self, mock_formatter, mock_scanner_class, mock_validate_path, mock_check_git
     ):
@@ -46,7 +46,7 @@ class TestCliIntegration:
     @patch("cli.validate_path")
     @patch("cli.GitScanner")
     @patch("cli.TableFormatter")
-    @patch("sys.argv", ["gsk", "--detailed"])
+    @patch("sys.argv", ["gitskan", "--detailed"])
     def test_cli_full_workflow_with_repositories(
         self, mock_formatter, mock_scanner_class, mock_validate_path, mock_check_git
     ):
@@ -87,7 +87,7 @@ class TestCliIntegration:
         mock_scanner.get_summary_stats.assert_called_once()
 
     @patch("cli.check_git_availability")
-    @patch("sys.argv", ["gsk"])
+    @patch("sys.argv", ["gitskan"])
     def test_cli_git_not_available(self, mock_check_git):
         """Test CLI when git is not available."""
         mock_check_git.return_value = False


### PR DESCRIPTION
# Summary
Updates CLI command name from `gsk` to `gitskan` and bumps version to `0.0.7`.

# Details
CLI Command Update
- Command rename: Change CLI entry point from `gsk` to `gitskan` in `pyproject.toml`
- Test updates: Update test files to use the new command name
- Integration tests: Update integration test scenarios to reflect the command change

Documentation
- `README.md` updates:  Documentation to reflect the new CLI command name
  - Usage examples: Update all command examples throughout the documentation